### PR TITLE
feat: add dielectric and compressibility protocols for MD simulation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2025 ByteDance and/or its affiliates.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/byteff2/md_utils/md_run.py
+++ b/byteff2/md_utils/md_run.py
@@ -162,14 +162,15 @@ def rescale_box(
 
 
 def nvt_run(
-        top: GromacsTopFile,
-        system: omm.System,
-        positions: list[omm.Vec3],
-        box_vec: Optional[omm.Vec3],
-        temperature: float,
-        work_dir: str,
-        nvt_steps: int,
-        timestep: int = 2  # fs
+    top: GromacsTopFile,
+    system: omm.System,
+    positions: list[omm.Vec3],
+    box_vec: Optional[omm.Vec3],
+    temperature: float,
+    work_dir: str,
+    nvt_steps: int,
+    timestep: int = 2,  # fs
+    extra_reporters: list | None = None,
 ):
     top = copy.deepcopy(top)
     system = copy.deepcopy(system)
@@ -201,13 +202,16 @@ def nvt_run(
         reportInterval=500,
         enforcePeriodicBox=False,
     )
+    reporters = [state_reporter, dcd_reporter]
+    if extra_reporters:
+        reporters.extend(extra_reporters)
     return openmm_run(
         task_name='nvt',
         top=top,
         system=system,
         positions=positions,
         integrator=integrator,
-        reporter=[state_reporter, dcd_reporter],
+        reporter=reporters,
         work_dir=work_dir,
         minimize=False,
         box_vec=box_vec,
@@ -233,3 +237,111 @@ def dcd_read(fp):
             position.append(frame.xyz.copy())
     position = np.array(position)
     return position
+
+
+class DipoleReporter:
+    """
+    Reporter for recording the total dipole moment of a system using the AMOEBA force field.
+    This version considers only permanent charges (monopoles) and induced dipoles.
+    
+    Units:
+    - Time: ps
+    - Dipole components and magnitude: e*Angstrom
+    """
+
+    def __init__(self, file_path, reportInterval, system):
+        """
+        Initialize the reporter.
+        
+        Parameters
+        ----------
+        file_path : str
+            Path to the output CSV file.
+        reportInterval : int
+            The interval (in steps) at which to write to the file.
+        system : openmm.System
+            The OpenMM System object to extract force and charge information.
+        """
+        self._reportInterval = int(reportInterval)
+        self._file_path = file_path
+
+        # 1. Locate the AmoebaMultipoleForce
+        self._amoeba_force = None
+        for i in range(system.getNumForces()):
+            f = system.getForce(i)
+            if isinstance(f, omm.AmoebaMultipoleForce):
+                self._amoeba_force = f
+                break
+
+        if self._amoeba_force is None:
+            raise RuntimeError("AmoebaMultipoleForce not found in the System.")
+
+        # 2. Pre-extract permanent charges (monopoles)
+        n_particles = system.getNumParticles()
+        self._charges = np.zeros(n_particles)
+        for i in range(n_particles):
+            # params[0] is the charge q in units of elementary_charge
+            params = self._amoeba_force.getMultipoleParameters(i)
+            self._charges[i] = params[0].value_in_unit(ou.elementary_charge)
+
+        # 3. Initialize the output file and write the header
+        os.makedirs(os.path.dirname(os.path.abspath(file_path)), exist_ok=True)
+        self._out = open(file_path, 'w')
+        self._out.write('time_ps,Mx_eA,My_eA,Mz_eA,M_mag_eA\n')
+        self._out.flush()
+
+    def describeNextReport(self, simulation):
+        """
+        Describe the requirements for the next report.
+        periodic=False is crucial: it requests unwrapped coordinates where 
+        molecules are kept whole across periodic boundaries.
+        """
+        steps = self._reportInterval - simulation.currentStep % self._reportInterval
+        return {'steps': steps, 'periodic': False, 'include': ['positions']}
+
+    def report(self, simulation, state):
+        """
+        Calculate and record the dipole moment for the current state.
+        """
+        # 1. Get simulation time in ps
+        t_ps = state.getTime().value_in_unit(ou.picoseconds)
+
+        # 2. Get unwrapped positions in Angstroms
+        # Because periodic=False, molecules are not torn by PBC
+        pos = state.getPositions(asNumpy=True).value_in_unit(ou.angstrom)
+
+        # 3. Calculate Monopole Contribution: sum(q_i * r_i)
+        # Result in e * Angstrom
+        m_monopole = np.sum(self._charges[:, np.newaxis] * pos, axis=0)
+
+        # 4. Get Induced Dipoles from AMOEBA
+        try:
+            mu_ind_list = self._amoeba_force.getInducedDipoles(simulation.context)
+        except omm.OpenMMException:
+            # Re-initialize force reference if the Context has been updated/rebuilt
+            self._reinit_force(simulation.system)
+            mu_ind_list = self._amoeba_force.getInducedDipoles(simulation.context)
+
+        # 5. Convert induced dipoles from e*nm to e*A and sum them up
+        m_induced = np.array(mu_ind_list).sum(axis=0) * 10
+
+        # 6. Total Dipole Vector
+        m_total = m_monopole + m_induced
+        m_mag = np.linalg.norm(m_total)
+
+        # 7. Write to CSV file
+        self._out.write(f"{t_ps:.4f},{m_total[0]:.6f},{m_total[1]:.6f},{m_total[2]:.6f},{m_mag:.6f}\n")
+        self._out.flush()
+
+    def _reinit_force(self, system):
+        """Re-locate the AmoebaMultipoleForce instance in the System."""
+        for i in range(system.getNumForces()):
+            f = system.getForce(i)
+            if isinstance(f, omm.AmoebaMultipoleForce):
+                self._amoeba_force = f
+                break
+
+    def __del__(self):
+        """Ensure the file is closed properly."""
+        if hasattr(self, '_out'):
+            self._out.close()

--- a/byteff2/toolkit/protocol.py
+++ b/byteff2/toolkit/protocol.py
@@ -9,13 +9,16 @@ import ase.io as aio
 import numpy as np
 import openmm.app as app
 import pandas as pd
+from numpy.typing import NDArray
+from scipy import signal
 
-from byteff2.md_utils.md_run import dcd_read, npt_run, nvt_run, rescale_box, volume_calc
+from byteff2.md_utils.md_run import DipoleReporter, dcd_read, npt_run, nvt_run, rescale_box, volume_calc
 from byteff2.md_utils.onsager_conductivity import onsager_calc
 from byteff2.md_utils.viscosity import nonequ_run, viscosity_calc
 from byteff2.toolkit.gmxtool import GMXScript
 from byteff2.toolkit.openmmtool import generate_openmm_system
 from byteff2.train.utils import get_nb_params, load_model
+from byteff2.utils.definitions import CHG_FACTOR
 from bytemol.core import Molecule
 from bytemol.toolkit.gmxtool.topparse import RecordAtomType, RecordMolecule, Records, TopoFullSystem
 from bytemol.utils import get_data_file_path, setup_default_logging
@@ -519,5 +522,244 @@ class HVapProtocol(Protocol):
 
         with open(os.path.join(self.output_dir, 'hvap_results.json'), 'w') as f:
             json.dump(result, f, indent=4)
+        logger.info(result)
+        return result
+
+
+class DielectricProtocol(Protocol):
+
+    def __init__(self, config: dict):
+        super().__init__(config['params_dir'], config['output_dir'])
+        self.config = config
+        self.components = None
+
+    def run_protocol(self):
+        logger.info('running dielectric protocol')
+        # steps configurable via JSON; defaults provide adequate sampling
+        npt_steps = int(self.config.get('npt_steps', 2000000))
+        nvt_steps = int(self.config.get('nvt_steps', 6000000))
+        dipole_interval = int(self.config.get('dipole_interval', 500))
+        nonbonded_params = self.generate_ff_params(self.config['smiles'])
+        self.components = self.build_system(
+            self.config['natoms'],
+            self.config['components'],
+            self.config['working_dir'],
+        )
+        gro_file = f"{self.params_dir}/solvent_salt.gro"
+        top_file = f"{self.params_dir}/system.top"
+        grofileparser = app.GromacsGroFile(gro_file)
+        input_positions = grofileparser.positions
+        unit_cell = grofileparser.getUnitCellDimensions()
+        input_top, input_system = generate_openmm_system(
+            top_file,
+            nonbonded_params,
+            unit_cell,
+        )
+        logger.info('npt run')
+        npt_positions, npt_box_vec = npt_run(
+            input_top,
+            input_system,
+            input_positions,
+            temperature=self.config['temperature'],
+            npt_steps=npt_steps,
+            work_dir=self.output_dir,
+        )
+        rescale_positions, rescale_box_vec = rescale_box(npt_positions, npt_box_vec, work_dir=self.output_dir)
+        logger.info('nvt run with dipole recording')
+        dipole_reporter = DipoleReporter(
+            file_path=os.path.join(self.output_dir, 'dipole.csv'),
+            reportInterval=dipole_interval,
+            system=input_system,
+        )
+        _nvt_positions, _nvt_box_vec = nvt_run(
+            input_top,
+            input_system,
+            rescale_positions,
+            rescale_box_vec,
+            temperature=self.config['temperature'],
+            work_dir=self.output_dir,
+            nvt_steps=nvt_steps,
+            extra_reporters=[dipole_reporter],
+        )
+
+    def post_process(self,):
+
+        def _correlate_1d(in1: NDArray, in2: NDArray, average: bool) -> tuple[NDArray, NDArray]:
+            N = len(in1)
+            assert N == len(in2)
+
+            result = signal.correlate(in1, in2, mode="full", method="auto")
+            c12 = result[N - 1:]
+            c21 = result[::-1][N - 1:]
+            if average:
+                div = np.arange(N, 0, -1)
+                c12 = c12 / div
+                c21 = c21 / div
+                # "c12 /= div; c21 /= div" will not work because result[N-1]
+                # will be divided by div[0]**2 due to the in-place operation.
+            return c12, c21
+
+        def correlate(in1: NDArray, in2: NDArray, average: bool = True) -> tuple[NDArray, NDArray]:
+            shape1 = in1.shape
+            dim1 = len(shape1)
+            assert dim1 in (1, 2)
+            if dim1 == 1:
+                return _correlate_1d(in1, in2, average)
+            assert shape1 == in2.shape
+
+            N, D = shape1
+            c12, c21 = np.zeros(N), np.zeros(N)
+            for i in range(D):
+                c12i, c21i = _correlate_1d(in1[:, i], in2[:, i], average)
+                c12 += c12i
+                c21 += c21i
+            return c12, c21
+
+        def calculate_dipole_autocorrelation(Mx, My, Mz):
+            """Calculate dipole moment autocorrelation function (DACF)"""
+            # Create dipole moment vector
+            dipole = np.vstack([Mx, My, Mz]).T
+
+            # Calculate autocorrelation function
+            dacf, _ = correlate(dipole, dipole, average=True)
+
+            return dacf
+
+        def calculate_correlation_time(dacf, dt):
+            """
+            Calculate correlation time from dipole autocorrelation function.
+            
+            Parameters
+            ----------
+            dacf : np.ndarray
+                Dipole autocorrelation function
+            dt : float
+                Time step between frames (in ps)
+            
+            Returns
+            -------
+            correlation_time : float
+                Correlation time (in ps)
+            """
+            dacf = dacf / dacf[0]
+            under_cutoff = np.where(dacf < 0.05)[0]
+            if len(under_cutoff) == 0:
+                cutoff = len(dacf)
+            else:
+                cutoff = under_cutoff[0]
+
+            # Integrate DACF using trapezoidal rule to get correlation time
+            correlation_time = np.trapz(dacf[:cutoff], dx=dt)
+
+            return correlation_time
+
+        logger.info('post processing dielectric protocol')
+        # Read dipole series and thermodynamic quantities
+        dip_csv = os.path.join(self.output_dir, 'dipole.csv')
+        df = pd.read_csv(dip_csv)
+        md_volume_A3, _ = volume_calc(self.output_dir)
+
+        # use later part of trajectory to avoid initial relaxation bias
+        start_index = int(len(df) * 0.2)
+        Mx = df['Mx_eA'].values[start_index:]
+        My = df['My_eA'].values[start_index:]
+        Mz = df['Mz_eA'].values[start_index:]
+
+        M2_mean = np.mean(Mx**2 + My**2 + Mz**2)
+        M_mean_sq = np.mean(Mx)**2 + np.mean(My)**2 + np.mean(Mz)**2
+        fluct = float(M2_mean - M_mean_sq)
+
+        eps0_star = 1.0 / (4.0 * np.pi * CHG_FACTOR)
+        R_gas = 1.9872036 * 1e-3
+        V = md_volume_A3  # in A^3
+        T = self.config['temperature']  # in K
+
+        dielectric = 1.0 + fluct / (3.0 * eps0_star * V * R_gas * T)
+
+        # Calculate dipole autocorrelation function and correlation time
+        dt = 2.0 * self.config.get('dipole_interval', 500) * 1e-3  # ps (timestep in fs, every N steps)
+        dacf = calculate_dipole_autocorrelation(Mx, My, Mz)
+        correlation_time = calculate_correlation_time(dacf, dt)
+
+        result = {
+            'dielectric': float(dielectric),
+            'volume': float(md_volume_A3),
+            "correlation_time": float(correlation_time),
+            'units': {
+                'dielectric': 'dimensionless',
+                'volume': 'Angstrom^3',
+                'correlation_time': 'ps',
+            },
+        }
+        with open(os.path.join(self.output_dir, 'dielectric_results.json'), 'w') as f:
+            json.dump(result, f, indent=2)
+        logger.info(result)
+        return result
+
+
+class CompressibilityProtocol(Protocol):
+
+    def __init__(self, config: dict):
+        super().__init__(config['params_dir'], config['output_dir'])
+        self.config = config
+        self.components = None
+
+    def run_protocol(self):
+        logger.info('running compressibility protocol')
+        # steps configurable via JSON; defaults provide adequate sampling
+        npt_steps = int(self.config.get('npt_steps', 5000000))
+        assert npt_steps > 1000000, "npt_steps must be greater than 1000000"
+        nonbonded_params = self.generate_ff_params(self.config['smiles'])
+        self.components = self.build_system(
+            self.config['natoms'],
+            self.config['components'],
+            self.config['working_dir'],
+        )
+        gro_file = f"{self.params_dir}/solvent_salt.gro"
+        top_file = f"{self.params_dir}/system.top"
+        grofileparser = app.GromacsGroFile(gro_file)
+        input_positions = grofileparser.positions
+        unit_cell = grofileparser.getUnitCellDimensions()
+        input_top, input_system = generate_openmm_system(
+            top_file,
+            nonbonded_params,
+            unit_cell,
+        )
+        logger.info('npt run')
+        _npt_positions, _npt_box_vec = npt_run(
+            input_top,
+            input_system,
+            input_positions,
+            temperature=self.config['temperature'],
+            npt_steps=npt_steps,
+            work_dir=self.output_dir,
+        )
+
+    def post_process(self,):
+
+        def compressibility(volume, temp):
+            kb = 1.380649e-23  # J/K
+            v_mean = np.mean(volume)
+            dv2_mean = np.mean((volume - v_mean)**2)
+            comp = dv2_mean / (v_mean * kb * temp) * 1e9  # GPa^-1
+            return comp
+
+        logger.info('post processing compressibility protocol')
+        # Read dipole series and thermodynamic quantities
+        csv_file = os.path.join(self.output_dir, 'npt_state.csv')
+        volume_m3 = pd.read_csv(csv_file)["Box Volume (nm^3)"].to_numpy() * 1e-27
+        md_volume_A3, _ = volume_calc(self.output_dir)
+        skip_steps = 1000  # skip first 1 ns
+        comp = compressibility(volume_m3[skip_steps:], self.config['temperature'])
+        result = {
+            'compressibility': float(comp),
+            'volume': float(md_volume_A3),
+            'units': {
+                'compressibility': 'GPa^-1',
+                'volume': 'Angstrom^3'
+            },
+        }
+        with open(os.path.join(self.output_dir, 'compressibility_results.json'), 'w') as f:
+            json.dump(result, f, indent=2)
         logger.info(result)
         return result

--- a/example/4_MD_simulations/README.md
+++ b/example/4_MD_simulations/README.md
@@ -6,6 +6,8 @@ The MD simulations example shows how to:
 * Run NPT simulations for density calculations
 * Run liquid and gas phase simulations to evaluate evaporation enthalpy (Hvap).
 * Conduct a simulation to compute transport properties such as viscosity, conductivity and so on.
+* Run NPT and NVT simulations to compute dielectric constant.
+* Run NPT simulations to compute isothermal compressibility.
 
 ## How to Run
 0. Set PYTHONPATH
@@ -17,13 +19,17 @@ If you want to run MD simulations for density calculations, run:
 ```bash
 python run_md.py --config density_config.json
 ```
+If you want to run MD simulations for dielectric constant calculations, run:
+```bash
+python run_md.py --config dielectric_config.json
+```
 The config files for other simulations, like evaporation enthalpy (Hvap) and transport properties, are also provided. To run these simulations, simply replace `density_config.json` with the corresponding config file.
 
 ## Configuration File Details (*_config.json)
 
 This configuration is used for running transport property simulations (viscosity and conductivity) on electrolyte systems:
 
-* **protocol**: "Transport" - Specifies the simulation protocol type, including `Transport`, `Density` and `HVap`.
+* **protocol**: "Transport" - Specifies the simulation protocol type, including `Transport`, `Density`, `HVap`,  `Dielectric` and `Compressibility`.
 * **temperature**: 298 - Simulation temperature in Kelvin
 * **natoms**: 10000 - Total number of atoms in the box
 * **components**: Molecular composition with **molecule ratio**:

--- a/example/4_MD_simulations/compressibility_config.json
+++ b/example/4_MD_simulations/compressibility_config.json
@@ -1,0 +1,15 @@
+{
+    "protocol": "Compressibility",
+    "params_dir": "compressibility_params",
+    "output_dir": "compressibility_results",
+    "working_dir": "compressibility_working_dir",
+    "temperature": 298,
+    "natoms": 5000,
+    "npt_steps": 5000000,
+    "components": {
+        "DMC": 1
+    },
+    "smiles": {
+        "DMC": "COC(=O)OC"
+    }
+}

--- a/example/4_MD_simulations/dielectric_config.json
+++ b/example/4_MD_simulations/dielectric_config.json
@@ -1,0 +1,17 @@
+{
+    "protocol": "Dielectric",
+    "params_dir": "dielectric_params",
+    "output_dir": "dielectric_results",
+    "working_dir": "dielectric_working_dir",
+    "temperature": 298,
+    "natoms": 5000,
+    "npt_steps": 2000000,
+    "nvt_steps": 8000000,
+    "dipole_interval": 1000,
+    "components": {
+        "DMC": 1
+    },
+    "smiles": {
+        "DMC": "COC(=O)OC"
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ GitPython~=3.1.45
 torch-geometric==2.6.1
 Sella==2.3.5
 pytest-xdist~=3.5
+scipy~=1.12
 
 isort~=6.0.1
 pylint~=3.3.8


### PR DESCRIPTION

* Added `DipoleReporter` to `byteff2/md_utils/md_run.py` to record total dipole moment
* Implemented `DielectricProtocol` and `CompressibilityProtocol` in `byteff2/toolkit/protocol.py` for computing dielectric constant and isothermal compressibility
* Updated MD simulation examples and README with the new protocols and configs
* Added `scipy` dependency to `requirements.txt` for post-processing
* Updated copyright year in `LICENSE`